### PR TITLE
Added CommonJS export.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./angular-promise-cache');
+
+module.exports = 'angular-promise-cache';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-promise-cache",
   "version": "0.0.13",
   "description": "AngularJS service that provides a generic way to cache promises and ensure all cached promises are resolved correctly.",
-  "main": "angular-promise-cache.js",
+  "main": "index.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
I think it would be good to add CommonJS import option to your service. 

That was the first thing I've noticed after installing it. I'm using Babel with ES6 imports with webpack for bundling my angular app and to have the import work I needed that modification.

Your tests are still passing (not affected by this modification) and I've taken the implementation from `angular-ui-router`.