### PR TITLE
Force expiration only if memo still exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Please view the detailed [demo](http://www.chrisronline.com/angular-promise-cach
 Testing
 ---------
 
+    npm install
+    bower install
     gulp test
 
 Release Notes

--- a/angular-promise-cache.js
+++ b/angular-promise-cache.js
@@ -214,7 +214,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           },
           function(error) {
             if (angular.isFunction(expireOnFailure) && expireOnFailure.apply(this, arguments)) {
-              memos[strPromise].forceExpiration = true;
+              var memo = memos[strPromise];
+              if (memo) {
+                memo.forceExpiration = true;
+              }
             }
             return $q.reject(error);
           }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-uglify": "^1.4.2",
     "karma": "^0.13.15",
     "karma-jasmine": "~0.1.0",
-    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "phantomjs": "^1.9.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-uglify": "^1.4.2",
     "karma": "^0.13.15",
     "karma-jasmine": "~0.1.0",
-    "karma-phantomjs-launcher": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.4",
     "phantomjs": "^1.9.18"
   }
 }


### PR DESCRIPTION
This should prevent errors of this type:

```
TypeError: Cannot set property 'forceExpiration' of undefined
```

This can happen because this code is executed in a promise error callback, which is not in the same event loop as where the memo is created on line 163. Between the time the memo was created and the time of line 217's execution, line 257 `delete memos[key]` could have already executed.

This helps ensure stability of applications that pass in an `expireOnFailure` function.

